### PR TITLE
From vector to span

### DIFF
--- a/Detectors/MUON/MCH/Raw/Tools/.clang-format
+++ b/Detectors/MUON/MCH/Raw/Tools/.clang-format
@@ -1,0 +1,3 @@
+DisableFormat: true
+SortIncludes: false
+

--- a/Detectors/MUON/MCH/Raw/Tools/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Raw/Tools/DataDecoderSpec.cxx
@@ -81,7 +81,8 @@ public:
       //std::cout<<"raw:     "<<(void*)raw<<std::endl;
       //std::cout<<"payload: "<<(void*)payload<<std::endl;
 
-      std::vector<uint8_t> buffer((uint8_t*)raw, ((uint8_t*)raw)+payloadSize+sizeof(o2::header::RAWDataHeaderV4));
+     //  std::vector<uint8_t> buffer((uint8_t*)raw, ((uint8_t*)raw)+payloadSize+sizeof(o2::header::RAWDataHeaderV4));
+      gsl::span<uint8_t> buffer(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(raw)), payloadSize+sizeof(o2::header::RAWDataHeaderV4));
       decoder.decodeBuffer(buffer, digits);
     }
 

--- a/Detectors/MUON/MCH/Raw/Tools/RawBufferDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Tools/RawBufferDecoder.h
@@ -76,10 +76,9 @@ public:
     cruLink2solar = o2::mch::raw::createCruLink2SolarMapper<ElectronicMapperGenerated>();
   }
 
-  void decodeBuffer(std::vector<uint8_t> &buffer, std::vector<o2::mch::Digit> &digits)
+  void decodeBuffer(gsl::span<uint8_t> sbuffer, std::vector<o2::mch::Digit> &digits)
   {
     //bool verbose = false;
-    gsl::span<uint8_t> sbuffer(buffer);
 
     size_t ndigits{0};
 


### PR DESCRIPTION
Comme discuté ce matin, voici comment passer une span plutôt qu'un vecteur. 
Le casting est un peu sale et c'est ma faute : pour le simplifier il faudrait que l'interface de mon  décodeur soit : 

```c++
using Decoder = std::function<DecoderStat(gsl::span<const uint8_t> buffer)>;
```

plutôt que l'existant : 

```c++
using Decoder = std::function<DecoderStat(gsl::span<uint8_t> buffer)>;
```

Je changerai cela dans une prochaine PR (avec le changement du décodeur UL, par exemple).