### PR TITLE
Mrrtf 204 fix eos in calibrator

### DIFF
--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
@@ -133,25 +133,36 @@ class PedestalDataIterator
     return &mMapIt->second[mRow][mCol];
   }
 
-  PedestalDataIterator& operator++()
+  bool advance()
   {
     if (mMapIt != mData->mPedestals.end()) {
       if (mCol < PedestalData::MAXCHANNEL - 1) {
         mCol++;
-        return *this;
+        return true;
       }
       if (mRow < PedestalData::MAXDS - 1) {
         mCol = 0;
         mRow++;
-        return *this;
+        return true;
       }
       ++mMapIt;
       mCol = 0;
       mRow = 0;
       if (mMapIt != mData->mPedestals.end()) {
-        return *this;
+        return true;
       }
       mData = nullptr;
+    }
+    // undefined behavior here (should not increment an end iterator)
+    return false;
+  }
+
+  PedestalDataIterator& operator++()
+  {
+    while (advance()) {
+      if ((*this)->isValid()) {
+        break;
+      }
     }
     // undefined behavior here (should not increment an end iterator)
     return *this;

--- a/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrator.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrator.cxx
@@ -71,7 +71,7 @@ bool BadChannelCalibrator::hasEnoughData(const Slot& slot) const
   const int requiredChannels = static_cast<int>(BadChannelCalibratorParam::Instance().minRequiredCalibratedFraction * nofChannels);
 
   auto nofCalibrated = std::count_if(pedData->cbegin(), pedData->cend(),
-                                     [&](const PedestalChannel& c) { return (c.isValid() && (c.mEntries > minNofEntries)); });
+                                     [&](const PedestalChannel& c) { return c.mEntries > minNofEntries; });
 
   bool hasEnough = nofCalibrated > requiredChannels;
 
@@ -100,7 +100,7 @@ void BadChannelCalibrator::finalizeSlot(Slot& slot)
   }
 
   for (const auto& ped : *pedestalData) {
-    if (!ped.isValid() || ped.mEntries == 0) {
+    if (ped.mEntries == 0) {
       continue;
     }
     mPedestalsVector.emplace_back(ped);

--- a/Detectors/MUON/MCH/Calibration/test/example-mch-pedestal-calibration.sh
+++ b/Detectors/MUON/MCH/Calibration/test/example-mch-pedestal-calibration.sh
@@ -1,7 +1,10 @@
+date
+
 o2-raw-tf-reader-workflow --input-data \
-    $HOME/alice/data/2022/MAY/514781/raw/1100 --onlyDet MCH --max-tf 10 | \
+    $HOME/alice/data/2022/LHC22t_MCH/529437/calib/1140 --onlyDet MCH --max-tf 1000 | \
 o2-mch-pedestal-decoding-workflow | \
-o2-calibration-mch-badchannel-calib-workflow | \
+o2-calibration-mch-badchannel-calib-workflow \
+  --configKeyValues="MCHBadChannelCalibratorParam.minRequiredNofEntriesPerChannel=10;MCHBadChannelCalibratorParam.minRequiredCalibratedFraction=0.5;MCHBadChannelCalibratorParam.onlyAtEndOfStream=true" | \
 o2-calibration-ccdb-populator-workflow \
     --ccdb-path http://localhost:6464 \
     --sspec-min 0 --sspec-max 0 | \
@@ -9,3 +12,4 @@ o2-calibration-ccdb-populator-workflow \
     --ccdb-path localhost:8484 --sspec-max 1 --sspec-min 1 --name-extention dcs | \
 o2-dpl-run --run -b
 
+date


### PR DESCRIPTION
@aferrero2707 here's how I would change the `PedestalData` so it only loops over valid channel (hence avoiding a couple of explicit `PedestalChannel::isValid` calls elsewhere). Tested briefly only...